### PR TITLE
Try to fix images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: Ivo's Tech Blog
 email: pacnik@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   A tech blog about backend problems, personal projects and whatever else tech related I find I want to write about
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/ivos-tech-blog" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jutranjo
 github_username:  jutranjo


### PR DESCRIPTION
Hey, 

jeklly works in a way that it will copy all the folders that are not prefixed with `_` to a build/finished folder. So you have the `images` folder. 

So I can find you image here https://jutranjo.github.io/ivos-tech-blog/images/turtleResult1.png 

There is another convention that is screwing with you. https://www.w3schools.com/html/html_filepaths.asp  Your destination of the image is actually `ivos-tech-blog/images/turtleResult1.png` because github will add a path prefix for the repo name. 

I guess all you have to do is to fix the `baseurl` setting.